### PR TITLE
correct version tag for libsearpc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,7 +111,7 @@ build_libsearpc()
     git clone https://github.com/haiwen/libsearpc.git
     cd libsearpc
   fi
-  git reset --hard $VERSION_TAG
+  git reset --hard $LIBSEARPC_TAG
   ./autogen.sh
   ./configure
   make dist


### PR DESCRIPTION
Changed the version tag in build_libsearpc() to LIBSEARPC_TAG